### PR TITLE
Hopefully name loot pools properly so there's no conflict with other …

### DIFF
--- a/src/main/java/com/teamabnormals/upgrade_aquatic/core/events/LootEvents.java
+++ b/src/main/java/com/teamabnormals/upgrade_aquatic/core/events/LootEvents.java
@@ -28,11 +28,11 @@ public class LootEvents {
 	@SubscribeEvent
 	public static void onInjectLoot(LootTableLoadEvent event) {
 		if (PICKERELWEED_LOOT_INJECTIONS.contains(event.getName())) {
-			LootPool pool = LootPool.builder().addEntry(TableLootEntry.builder(new ResourceLocation(Reference.MODID, "injections/pickerelweed_structures")).weight(1).quality(0)).build();
+			LootPool pool = LootPool.builder().addEntry(TableLootEntry.builder(new ResourceLocation(Reference.MODID, "injections/pickerelweed_structures")).weight(1).quality(0)).name("pickerelweed_structure").build();
 			event.getTable().addPool(pool);
 		}
 		if(PICKERELWEED_FISHINGJUNK_LOOT_INJECTIONS.contains(event.getName())) {
-			LootPool pool = LootPool.builder().addEntry(TableLootEntry.builder(new ResourceLocation(Reference.MODID, "injections/pickerelweed_fishjunk")).weight(1).quality(0)).build();
+			LootPool pool = LootPool.builder().addEntry(TableLootEntry.builder(new ResourceLocation(Reference.MODID, "injections/pickerelweed_fishjunk")).weight(1).quality(0)).name("pickerelweed_fishing").build();
 			event.getTable().addPool(pool);
 		}
 	}


### PR DESCRIPTION
…mods.

If you fail to name a loot pool, it results in a NullPointerException
the next time something tries to inject into that pool, causing the loot
table to just fail to load entirely.