### PR TITLE
Move subtitles to lang files for translations

### DIFF
--- a/src/main/resources/assets/upgrade_aquatic/lang/en_us.json
+++ b/src/main/resources/assets/upgrade_aquatic/lang/en_us.json
@@ -573,5 +573,15 @@
   "advancements.husbandry.eat_pickerelweed.description": "Smoke and eat Boiled Pickerelweed to regain water bubbles",
   
   "advancements.husbandry.collect_all_pike.title": "Pike World Tour",
-  "advancements.husbandry.collect_all_pike.description": "Collect every variant of Pike in a bucket"
+  "advancements.husbandry.collect_all_pike.description": "Collect every variant of Pike in a bucket",
+  
+  "_comment8": "Subtitles",
+  
+  "subtitles.upgrade_aquatic.thrasher.hurt": "Thrasher hurts",
+  "subtitles.upgrade_aquatic.thrasher.ambient": "Thrasher growls",
+  "subtitles.upgrade_aquatic.thrasher.death": "Thrasher dies",
+  "subtitles.upgrade_aquatic.thrasher.thrash": "Thrasher thrashes",
+  "subtitles.upgrade_aquatic.thrasher.flop": "Thrasher flops",
+  "subtitles.upgrade_aquatic.thrasher.sonar_fire": "Thrasher fires sonar"
+  
 }

--- a/src/main/resources/assets/upgrade_aquatic/sounds.json
+++ b/src/main/resources/assets/upgrade_aquatic/sounds.json
@@ -2,7 +2,7 @@
     "entity.thrasher.thrash":
     {
         "category": "entity",
-        "subtitle": "Thrasher Thrashes",
+        "subtitle": "subtitles.upgrade_aquatic.thrasher.thrash",
         "sounds": [
         	{ "name": "upgrade_aquatic:entity/thrasher/thrasher_thrash", "stream": false }
         ]
@@ -10,7 +10,7 @@
     "entity.thrasher.sonar_fire":
     {
         "category": "entity",
-        "subtitle": "Thrasher Fires Sonar",
+        "subtitle": "subtitles.upgrade_aquatic.thrasher.sonar_fire",
         "sounds": [
         	{ "name": "upgrade_aquatic:entity/thrasher/thrasher_sonar_0", "stream": false },
         	{ "name": "upgrade_aquatic:entity/thrasher/thrasher_sonar_1", "stream": false }
@@ -19,7 +19,7 @@
     "entity.thrasher.flop":
     {
         "category": "entity",
-        "subtitle": "Thrasher Flops",
+        "subtitle": "subtitles.upgrade_aquatic.thrasher.flop",
         "sounds": [
         	{ "name": "mob/guardian/flop1", "stream": false },
         	{ "name": "mob/guardian/flop2", "stream": false },
@@ -29,7 +29,7 @@
 	"entity.thrasher.ambient":
     {
         "category": "entity",
-        "subtitle": "Thrasher Growls",
+        "subtitle": "subtitles.upgrade_aquatic.thrasher.ambient",
         "sounds": [
         	{ "name": "upgrade_aquatic:entity/thrasher/thrasher_idle_0", "stream": false },
         	{ "name": "upgrade_aquatic:entity/thrasher/thrasher_idle_1", "stream": false },
@@ -39,7 +39,7 @@
     "entity.thrasher.ambient_land":
     {
         "category": "entity",
-        "subtitle": "Thrasher Growls Land",
+        "subtitle": "subtitles.upgrade_aquatic.thrasher.ambient",
         "sounds": [
         	{ "name": "upgrade_aquatic:entity/thrasher/thrasher_idle_land", "stream": false }
         ]
@@ -47,7 +47,7 @@
     "entity.thrasher.hurt":
     {
         "category": "entity",
-        "subtitle": "Thrasher Hurt",
+        "subtitle": "subtitles.upgrade_aquatic.thrasher.hurt",
         "sounds": [
         	{ "name": "upgrade_aquatic:entity/thrasher/thrasher_hurt_0", "stream": false },
         	{ "name": "upgrade_aquatic:entity/thrasher/thrasher_hurt_1", "stream": false },
@@ -57,7 +57,7 @@
     "entity.thrasher.hurt_land":
     {
         "category": "entity",
-        "subtitle": "Thrasher Hurt Land",
+        "subtitle": "subtitles.upgrade_aquatic.thrasher.hurt",
         "sounds": [
         	{ "name": "upgrade_aquatic:entity/thrasher/thrasher_hurt_0", "stream": false },
         	{ "name": "upgrade_aquatic:entity/thrasher/thrasher_hurt_1", "stream": false },
@@ -67,7 +67,7 @@
     "entity.thrasher.death":
     {
         "category": "entity",
-        "subtitle": "Thrasher Dies",
+        "subtitle": "subtitles.upgrade_aquatic.thrasher.death",
         "sounds": [
         	{ "name": "upgrade_aquatic:entity/thrasher/thrasher_death", "stream": false }
         ]
@@ -75,7 +75,7 @@
     "entity.thrasher.death_land":
     {
         "category": "entity",
-        "subtitle": "Thrasher Dies Land",
+        "subtitle": "subtitles.upgrade_aquatic.thrasher.death",
         "sounds": [
         	{ "name": "upgrade_aquatic:entity/thrasher/thrasher_death", "stream": false }
         ]


### PR DESCRIPTION
Also changed the case and phrasing of the subtitles to better fit vanilla's, and pointed some different sounds to the same subtitle (they can be easily given different subtitles again later if desired, but stuff like "Thrasher Growls Land" isn't a perfectly desirable description for a sound, and is more just unhelpfully parroting the sound event ID, so currently there's only one subtitle for every land/water sound pair). Should make translating these strings possible.