### PR TITLE
Fix error in EntityEvents.java/onPlayerSleep preventing player from sleeping if optional pos was not providen

### DIFF
--- a/src/main/java/com/minecraftabnormals/upgrade_aquatic/core/events/EntityEvents.java
+++ b/src/main/java/com/minecraftabnormals/upgrade_aquatic/core/events/EntityEvents.java
@@ -156,7 +156,11 @@ public class EntityEvents {
 	@SubscribeEvent
 	public static void onPlayerSleep(PlayerSleepInBedEvent event) {
 		PlayerEntity player = event.getPlayer();
-		BlockState state = player.getCommandSenderWorld().getBlockState(event.getPos());
+		BlockPos pos = event.getPos();
+		if (pos == null) return;
+
+		BlockState state = player.getCommandSenderWorld().getBlockState(pos);
+
 		if (event.getResultStatus() == null && state.getFluidState().getAmount() == 8 && state.getBlock() instanceof BedrollBlock) {
 			if (player instanceof ServerPlayerEntity && player.isAlive()) {
 				ServerPlayerEntity serverPlayer = (ServerPlayerEntity) player;


### PR DESCRIPTION
This error happens, for example, with mod [Sleeping Bags](https://www.curseforge.com/minecraft/mc-mods/sleeping-bags) [(issue)](https://github.com/team-abnormals/upgrade-aquatic/issues/241)